### PR TITLE
add WoL SP events to the campaign

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -44,6 +44,10 @@
     [load_resource]
         id = "joafm_items"
     [/load_resource]
+    # load wol specific code
+    [load_resource]
+        id=WOL_resource_abilities_events_all
+    [/load_resource]
 
     [about]
         title = _ "Author"


### PR DESCRIPTION
Closes #1 

![image](https://github.com/babaissarkar/frost-mage/assets/5283677/2cea6197-c24e-45c7-a301-03ea6bb7cd40)

Note: Do note that Jinx does not work on units with `canrecruit=yes` (due to MP balancing reasons). It works for regular units.
Maybe I should put that in the ability description to make communicate better.