### PR TITLE
Loads WoL the same way as other addons

### DIFF
--- a/_main.cfg
+++ b/_main.cfg
@@ -9,10 +9,6 @@
 
 {~/add-ons/Frost_Mage/utils}
 
-#ifhave ~add-ons/War_of_Legends/_main.cfg
-    {~add-ons/War_of_Legends/campaign-minimal.cfg}
-#endif
-
 #ifhave ~add-ons/WISh/_main.cfg
     {~add-ons/WISh/utils}
 #endif
@@ -141,6 +137,9 @@
 [/units]
 
 #ifdef CAMPAIGN_FROST_MAGE
+    # load War of legends
+    {~add-ons/War_of_Legends/campaign-minimal.cfg}
+    # load rest of the campaign resources
     {~/add-ons/Frost_Mage/scenarios}
     {~/add-ons/Frost_Mage/maps}
     {~/add-ons/Frost_Mage/images}


### PR DESCRIPTION
- Loads WoL the same way as other addons
- no more "duplicate" unit type warnings
- with exception of Fire Wisp as that was added to Wesnoth Core