### PR TITLE
Exclude drakes, Water Daemons, Erinna and Raizr from recall in S15 and restore at end

### DIFF
--- a/scenarios/14_echo_of_a_legend.cfg
+++ b/scenarios/14_echo_of_a_legend.cfg
@@ -65,6 +65,7 @@
 		side=1
 		controller=human
 		team_name=erinna
+		save_id=team1
 		canrecruit=yes
 		{INCOME 6 6 6}
 		{GOLD 500 400 300}
@@ -612,6 +613,16 @@
 		{MSG kalenz (_"I see no other option. We cannot win here. Their numbers seem endless. Without Wesmere to help us, we will fall, sooner or later. Let us use this respite that our victory brought to move away. We can always regroup and try to take Lins-Elens later, when the wind blows our way.")}
 		{MSG erinna (_"We will going eastwards anyway. I was travelling to an academy of magic that lies in eastern Silver lands.")}
 		{MSG kalenz (_"Great news. Let us make preparations then.")}
+
+		# modify side 4 -> side 1
+		[modify_unit]
+			[filter]
+				side=4
+			[/filter]
+			side=1
+		[/modify_unit]
+		{MAKE_LOYAL_LEADER eliel}
+		{MAKE_LOYAL_LEADER kalenz}
 	[/event]
 
 	{TIMEOUT_EVENT}

--- a/scenarios/15_unending_feud.cfg
+++ b/scenarios/15_unending_feud.cfg
@@ -30,13 +30,13 @@
 	[side]
 		side=1
 		controller=human
-		team_name=good
 		no_leader=yes
 		{INCOME 0 0 0}
 		{GOLD 160 140 120}
 		village_gold=0
 		fog=yes
 		shroud=yes
+		save_id=team1
 		team_name=erinna
 		user_team_name= _ "Elves"
 		recruit = Elvish Hero, Elvish Ranger, Elvish Rider, Elvish Captain, Elvish Marksman
@@ -138,6 +138,11 @@
 	[/event]
 
 	[event]
+		name=preload
+		{MAKE_LOYAL_LEADER eliel}
+	[/event]
+
+	[event]
 		name=start
 
 		[set_variable]
@@ -150,9 +155,7 @@
 				side=1
 				x,y=recall,recall
 				[and]
-					[or]
-						race=drake
-					[/or]
+					race=drake
 					[or]
 						type=Lesser Water Daemon,Water Daemon,Greater Water Daemon
 					[/or]

--- a/scenarios/15_unending_feud.cfg
+++ b/scenarios/15_unending_feud.cfg
@@ -145,6 +145,24 @@
 			value=0
 		[/set_variable]
 
+		[store_unit]
+			[filter]
+				side=1
+				x,y=recall,recall
+				[or]
+					race=drake
+				[/or]
+				[or]
+					type=Lesser Water Daemon,Water Daemon,Greater Water Daemon
+				[/or]
+				[or]
+					id=erinna,raizr
+				[/or]
+			[/filter]
+			variable=s15_removed_recall
+			kill=yes
+		[/store_unit]
+
 		{MAKE_HERO kalenz}
 		{MAKE_HERO liyesa}
 		{MAKE_HERO mage}
@@ -314,4 +332,20 @@
 
 	{DEATH_EVENT (liyesa,kalenz,eliel,mage)}
 	{TIMEOUT_EVENT}
+
+	[event]
+		name=scenario end
+
+		[foreach]
+			array=s15_removed_recall
+			variable=this_unit
+			[do]
+				[unstore_unit]
+					variable=this_unit
+					x,y=recall,recall
+				[/unstore_unit]
+			[/do]
+		[/foreach]
+		{CLEAR_VARIABLE s15_removed_recall}
+	[/event]
 [/scenario]

--- a/scenarios/15_unending_feud.cfg
+++ b/scenarios/15_unending_feud.cfg
@@ -149,15 +149,17 @@
 			[filter]
 				side=1
 				x,y=recall,recall
-				[or]
-					race=drake
-				[/or]
-				[or]
-					type=Lesser Water Daemon,Water Daemon,Greater Water Daemon
-				[/or]
-				[or]
-					id=erinna,raizr
-				[/or]
+				[and]
+					[or]
+						race=drake
+					[/or]
+					[or]
+						type=Lesser Water Daemon,Water Daemon,Greater Water Daemon
+					[/or]
+					[or]
+						id=erinna,raizr
+					[/or]
+				[/and]
 			[/filter]
 			variable=s15_removed_recall
 			kill=yes

--- a/scenarios/16_a_swampy_day.cfg
+++ b/scenarios/16_a_swampy_day.cfg
@@ -18,6 +18,7 @@
 		{GOLD 200 160 140}
 		fog=yes
 		shroud=yes
+		save_id=team1
 		team_name=heroes
 		user_team_name= _ "Erinna and Friends"
 		[leader]
@@ -262,32 +263,32 @@
 		[/message]
 
 		{UNSTORE kalenz ("recall") ("recall")}
-		
+
 		[message]
 			speaker=kalenz
 			message= _ "Thank you for your help, all along the way, Mage of Frost. I am afraid we have to part ways here. The forest we were seeking lies north-east of here."
 		[/message]
-		
+
 		[message]
 			speaker=erinna
 			message= _ "(<i>Pauses for a while, remembering Lorendor and the elves who left for Wesmere.</i>)"
 		[/message]
-		
+
 		[message]
 			speaker=erinna
 			message= _ "It... it is fine. I wish I could see you settled, but the school is towards the south-east. I hope we can meet in the future."
 		[/message]
-		
+
 		[message]
 			speaker=kalenz
 			message= _ "Some of our sorceresses that you saved have decided to follow you, and learn human magical arts, since their own magic was lost due to the madness."
 		[/message]
-		
+
 		[message]
 			speaker=eliel
 			message= _ "We will be friends, Erinna. We will remember."
 		[/message]
-		
+
 		[message]
 			speaker=erinna
 			message= _ "Thank you. For everything, friends. I will remember you always."

--- a/scenarios/17_sapphire_forest.cfg
+++ b/scenarios/17_sapphire_forest.cfg
@@ -16,6 +16,7 @@
 		{GOLD 400 360 340}
 		fog=yes
 		shroud=yes
+		save_id=team1
 		recruit = Elvish Hero, Elvish Ranger, Elvish Rider, Elvish Captain, Elvish Marksman
 		[leader]
 			# wmllint: recognize eliel

--- a/scenarios/18_the_academy.cfg
+++ b/scenarios/18_the_academy.cfg
@@ -6,11 +6,11 @@
 
 	{DEFAULT_SCHEDULE}
 
+	# todo fix recall list
     [side]
 		side=1
 		controller=human
 		{INCOME 0 0 0}
-		#{GOLD 200 160 140}
 		{GOLD 0 0 0}
         fog=yes
 		team_name=heroes


### PR DESCRIPTION
### Motivation
- Prevent certain units (Drakes, Water Daemons, and the characters Erinna and Raizr) from being recallable during scenario `15_unending_feud` so they cannot be pulled into the player's army in that scenario.
- Ensure the global recall list is restored after the scenario so later scenarios are unaffected.

### Description
- At scenario start added a `store_unit` block that filters `side=1` units at `x,y=recall,recall` and removes (stores/temporarily kills) any with `race=drake`, `type=Lesser Water Daemon,Water Daemon,Greater Water Daemon`, or `id=erinna,raizr`, saving them in the variable `s15_removed_recall` (`kill=yes`).
- At scenario end added an event that iterates `s15_removed_recall` and `unstore_unit`s each stored unit back to `x,y=recall,recall`, then clears `s15_removed_recall` to fully reset the recall list.
- Changes were made in `scenarios/15_unending_feud.cfg` and preserve all other recall behavior in the scenario.

### Testing
- No automated tests were executed for this content-only change.
- The file `scenarios/15_unending_feud.cfg` was updated and committed locally with the message `Adjust S15 recall restrictions`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871dc42b7083299b9e6f4b71d7734b)