### PR TITLE
Implement sequential Academy trials for Erinna, White Sorceress and Mage (adds mage wind gag)

### DIFF
--- a/scenarios/18_the_academy.cfg
+++ b/scenarios/18_the_academy.cfg
@@ -191,6 +191,7 @@
 		{VARIABLE fire_spawn_5_26 true}
 		{VARIABLE fire_spawn_7_13 true}
 		{VARIABLE fire_spawn_10_18 true}
+		{VARIABLE academy_current_test erinna}
 
 		[objectives]
 			side=1
@@ -257,7 +258,7 @@
 	# Erinna moves near key. Spawn Fire Guardian.
 	[event]
 		name=moveto
-		first_time_only=yes
+		first_time_only=no
 		[filter]
 			side=1
 			[filter_location]
@@ -265,32 +266,47 @@
 				radius=2
 			[/filter_location]
 		[/filter]
-		[unit]
-			side=4
-			type=Lava Giant
-			id=lava_giant
-			x,y=$academy_key_x,$academy_key_y
-			ai_special=guardian
-			name= _ "Fire Guardian"
-		[/unit]
-		{MSG instructor (_"A test guardian emerges. Defeat it to claim the key.")}
-		[scroll_to_unit]
-            [filter]
-                id=lava_giant
-            [/filter]
-        [/scroll_to_unit]
-		[objectives]
-			side=1
-			[objective]
-				description= _ "Defeat the Fire Guardian."
-				condition=win
-			[/objective]
-			[objective]
-				description= _ "Death of Erinna"
-				condition=lose
-			[/objective]
-			{TURNS_RUN_OUT}
-		[/objectives]
+		[if]
+			[variable]
+				name=academy_key_obtained
+				boolean_equals=false
+			[/variable]
+			[and]
+				[not]
+					[have_unit]
+						id=lava_giant
+					[/have_unit]
+				[/not]
+			[/and]
+			[then]
+				[unit]
+					side=4
+					type=Lava Giant
+					id=lava_giant
+					x,y=$academy_key_x,$academy_key_y
+					ai_special=guardian
+					name= _ "Fire Guardian"
+				[/unit]
+				{MSG instructor (_"A test guardian emerges. Defeat it to claim the key.")}
+				[scroll_to_unit]
+					[filter]
+						id=lava_giant
+					[/filter]
+				[/scroll_to_unit]
+				[objectives]
+					side=1
+					[objective]
+						description= _ "Defeat the Fire Guardian."
+						condition=win
+					[/objective]
+					[objective]
+						description= _ "Death of Erinna"
+						condition=lose
+					[/objective]
+					{TURNS_RUN_OUT}
+				[/objectives]
+			[/then]
+		[/if]
 	[/event]
 
 	# Fire Guardian defeated. Drop Key.
@@ -325,9 +341,9 @@
 	# Key picked up.
 	[event]
 		name=moveto
-		first_time_only=yes
+		first_time_only=no
 		[filter]
-			id=erinna
+			id=erinna,sorceress1,mage
 			[filter_location]
 				x,y=$academy_key_x,$academy_key_y
 			[/filter_location]
@@ -353,7 +369,10 @@
 					animate=yes
 					fire_event=no
 				[/kill]
-				{MSG erinna (_"This must be the key. Let's now go to the Academy.")}
+				[message]
+				speaker=$unit.id
+				message= _ "This must be the key. Let's now go to the Academy."
+			[/message]
 				[objectives]
 					side=1
 					[objective]
@@ -375,20 +394,35 @@
 		name=moveto
 		first_time_only=no
 		[filter]
-			id=erinna
+			id=erinna,sorceress1,mage
 			[filter_location]
 				x,y=24,13
 			[/filter_location]
 		[/filter]
 		[if]
-			[variable]
-				name=erinna_on_circle
-				boolean_equals=true
-			[/variable]
+			[or]
+				[variable]
+					name=erinna_on_circle
+					boolean_equals=true
+				[/variable]
+				[variable]
+					name=sorceress_on_circle
+					boolean_equals=true
+				[/variable]
+				[variable]
+					name=mage_on_circle
+					boolean_equals=true
+				[/variable]
+			[/or]
 			[then]
 				{REMOVE_IMAGE 10 18}
 				{CLEAR_VARIABLE erinna_on_circle}
-				{MSG erinna (_"Good! Just enough mana for what I need.")}
+				{CLEAR_VARIABLE sorceress_on_circle}
+				{CLEAR_VARIABLE mage_on_circle}
+				[message]
+				speaker=$unit.id
+				message= _ "Good! Just enough mana for what I need."
+			[/message]
 				# sfx, ignore now.
 				[delay]
 					time=50
@@ -397,15 +431,31 @@
 				# Place key somewhere is southwest, in the forest hexes
 				{MSG erinna (_"I can feel the key somewhere in that western grove.")}
 					{HIGHLIGHT_IMAGE 3 26 items/gohere.png ()}
-					{MSG erinna (_"I have to go there.")}
+					[message]
+					speaker=$unit.id
+					message= _ "I have to go there."
+				[/message]
 				# allow recruit (water elementals)
 				[modify_unit]
 					[filter]
-						id=erinna
+						id=$unit.id
 					[/filter]
 					canrecruit=yes
-					extra_recruit=Water Daemon,Ice Crab,Undine,Icemonax
 				[/modify_unit]
+				[if]
+					[variable]
+						name=unit.id
+						equals=erinna
+					[/variable]
+					[then]
+						[modify_unit]
+							[filter]
+								id=erinna
+							[/filter]
+							extra_recruit=Water Daemon,Ice Crab,Undine,Icemonax
+						[/modify_unit]
+					[/then]
+				[/if]
 				# fixme: difficulty golds (easy,normal,difficult -> 200,160,140)
 				[gold]
 					side=1
@@ -413,19 +463,27 @@
 				[/gold]
 
 				# Kwee auto-appears
-				[unit]
-					side=1
-					id=we1-loyal
-					type=Water Daemon
-					placement=leader
-				[/unit]
-				{MSG we1-loyal (_"Kwee!")}
-				{MSG erinna (_"Oh! Kwee, you want to help?")}
-				{MSG we1-loyal (_"Kwee! Kwee! Kwee!")}
-				{MSG instructor (_"Wait, where did that creature came from?")}
-				{MSG mage (_"That's her pet elemental. I doubt summoned creatures are against rules, are they?")}
-					{MSG instructor (_"Ahem... no... but her skill is decent. To have such loyality from a summoned magical being.")}
-					{MSG instructor (_"Regardless, let's proceed with the test.")}
+				[if]
+					[variable]
+						name=unit.id
+						equals=erinna
+					[/variable]
+					[then]
+						[unit]
+							side=1
+							id=we1-loyal
+							type=Water Daemon
+							placement=leader
+						[/unit]
+						{MSG we1-loyal (_"Kwee!")}
+						{MSG erinna (_"Oh! Kwee, you want to help?")}
+						{MSG we1-loyal (_"Kwee! Kwee! Kwee!")}
+						{MSG instructor (_"Wait, where did that creature came from?")}
+						{MSG mage (_"That's her pet elemental. I doubt summoned creatures are against rules, are they?")}
+						{MSG instructor (_"Ahem... no... but her skill is decent. To have such loyality from a summoned magical being.")}
+						{MSG instructor (_"Regardless, let's proceed with the test.")}
+					[/then]
+				[/if]
 
 				{VARIABLE joafm_s18_erinna_sensed true}
 
@@ -444,7 +502,6 @@
 
 				# start spawning enemies
 				{VARIABLE fire_elemental_spawn true}
-				{CLEAR_VARIABLE erinna_on_circle}
 			[/then]
 		[/if]
 	[/event]
@@ -495,9 +552,9 @@
 	# Erinna crosses water halfway
 	[event]
 		name=moveto
-		first_time_only=yes
+		first_time_only=no
 		[filter]
-			id=erinna
+			id=erinna,sorceress1,mage
 			[filter_location]
 				x="24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45"
 				y="28-33,28-34,26-33,25-34,23-33,23-34,22-34,22-34,21-34,21-34,20-34,20-34,19-33,19-30,18-28,18-27,18-26,18-26,17-24,17-23,16-22,17-22"
@@ -509,7 +566,7 @@
 				boolean_equals=true
 			[/variable]
 			[then]
-				{MSG instructor (_"She is halfway across already. Impressive.")}
+				{MSG instructor (_"$unit.name is halfway across already. Impressive.")}
 				{MSG instructor (_"Water guardians, stop her if you can. Erinna, defeat their leader to clear the Academy approach.")}
 				[unit]
 					side=4
@@ -560,9 +617,35 @@
 				boolean_equals=true
 			[/variable]
 			[then]
-				[fire_event]
-					name=sorceress_test
-				[/fire_event]
+				[if]
+					[variable]
+						name=academy_current_test
+						equals=erinna
+					[/variable]
+					[then]
+						[fire_event]
+							name=sorceress_test
+						[/fire_event]
+					[/then]
+					[else]
+						[if]
+							[variable]
+								name=academy_current_test
+								equals=sorceress
+							[/variable]
+							[then]
+								[fire_event]
+									name=mage_test
+								[/fire_event]
+							[/then]
+							[else]
+								[fire_event]
+									name=academy_passed
+								[/fire_event]
+							[/else]
+						[/if]
+					[/else]
+				[/if]
 			[/then]
 			[else]
 				{MSG instructor (_"Not yet. The southeastern island is sealed until the water guardian leader is defeated.")}
@@ -610,7 +693,10 @@
 		[filter]
 			id=water_leader
 		[/filter]
-		{MSG erinna (_"The leader is defeated. The way is clear, let's hasten to the Academy!")}
+		[message]
+			speaker=$second_unit.id
+			message= _ "The leader is defeated. The way is clear, let's hasten to the Academy!"
+		[/message]
 		{VARIABLE water_leader_defeated true}
 		[objectives]
 			side=1
@@ -642,8 +728,197 @@
 				id=sorceress1
 			[/filter]
 			type="White Sorceress Winged"
+			canrecruit=yes
 			extra_recruit="Orb"
 		[/modify_unit]
+		{VARIABLE academy_current_test sorceress}
+		{CLEAR_VARIABLE water_leader_defeated,academy_key_obtained,academy_key_dropped}
+		{VARIABLE sorceress_on_circle true}
+		{VARIABLE_OP academy_key_choice rand 1,2,3,4,5}
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=1
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 4}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=2
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 3}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=3
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 2}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=4
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 4}
+				{VARIABLE academy_key_y 27}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=5
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 3}
+				{VARIABLE academy_key_y 27}
+			[/then]
+		[/if]
+		{CLEAR_VARIABLE academy_key_choice}
+		{VARIABLE fire_spawn_5_26 true}
+		{VARIABLE fire_spawn_7_13 true}
+		{VARIABLE fire_spawn_10_18 true}
+		{HIGHLIGHT_IMAGE 24 13 items/gohere.png ()}
+		[objectives]
+			side=1
+			[objective]
+				description= _ "Move the White Sorceress to the marked place (mana hotspot)."
+				condition=win
+			[/objective]
+			[objective]
+				description= _ "Death of Erinna"
+				condition=lose
+			[/objective]
+			{TURNS_RUN_OUT}
+		[/objectives]
+	[/event]
+
+	[event]
+		name=mage_test
+		{MSG instructor (_"Well done, Lady $sorceress1.name. You pass this trial.")}
+		{MSG instructor (_"Now it is our Mage candidate's turn.")}
+		{TELEPORT_UNIT (id=sorceress1) 33 4}
+		{TELEPORT_UNIT (id=erinna) 32 2}
+		{TELEPORT_UNIT (id=mage) 24 12}
+		{MSG mage (_"Right... one small issue. I cannot fly. I also cannot swim.")}
+		{MSG mage (_"No panic. I'll just ask for help from a windy professional.")}
+		[unit]
+			side=3
+			id=mage_wind_friend
+			type=Greater Wind Daemon
+			x,y=23,12
+		[/unit]
+		{MSG mage_wind_friend (_"Who dares summon me in the middle of my glorious sky patrol?")}
+		{MSG mage (_"Great and mighty wind daemon, could you do me a tiny favor?")}
+		{MSG mage_wind_friend (_"A <i>tiny</i> favor from a <i>great</i> daemon? Dangerous wording.")}
+		{MSG mage (_"Just... carry me over the sea. Please?")}
+		{MSG mage_wind_friend (_"You summon me for ferry duty?")}
+		{MSG mage (_"Technically, for tactical aerial repositioning.")}
+		{MSG mage_wind_friend (_"...Fine. But you owe me a thunderstorm-sized offering later.")}
+		[kill]
+			id=mage_wind_friend
+			animate=no
+		[/kill]
+		[modify_unit]
+			[filter]
+				id=mage
+			[/filter]
+			movement_type=smallfly
+			canrecruit=yes
+			extra_recruit=Unstable Elemental,Vine Tiger,Zephyr,Stone Golem
+		[/modify_unit]
+		{VARIABLE academy_current_test mage}
+		{CLEAR_VARIABLE water_leader_defeated,academy_key_obtained,academy_key_dropped}
+		{VARIABLE mage_on_circle true}
+		{VARIABLE_OP academy_key_choice rand 1,2,3,4,5}
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=1
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 4}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=2
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 3}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=3
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 2}
+				{VARIABLE academy_key_y 26}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=4
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 4}
+				{VARIABLE academy_key_y 27}
+			[/then]
+		[/if]
+		[if]
+			[variable]
+				name=academy_key_choice
+				equals=5
+			[/variable]
+			[then]
+				{VARIABLE academy_key_x 3}
+				{VARIABLE academy_key_y 27}
+			[/then]
+		[/if]
+		{CLEAR_VARIABLE academy_key_choice}
+		{VARIABLE fire_spawn_5_26 true}
+		{VARIABLE fire_spawn_7_13 true}
+		{VARIABLE fire_spawn_10_18 true}
+		{HIGHLIGHT_IMAGE 24 13 items/gohere.png ()}
+		[objectives]
+			side=1
+			[objective]
+				description= _ "Move the Mage candidate to the marked place (mana hotspot)."
+				condition=win
+			[/objective]
+			[objective]
+				description= _ "Death of Erinna"
+				condition=lose
+			[/objective]
+			{TURNS_RUN_OUT}
+		[/objectives]
+	[/event]
+
+	[event]
+		name=academy_passed
+		{MSG instructor (_"Excellent. All three of you passed the test. Welcome to the Academy.")}
+		{MSG erinna (_"Thank you. We'll make good use of this chance.")}
+		[endlevel]
+			result=victory
+			bonus=yes
+		[/endlevel]
 	[/event]
 
 	{TIMEOUT_EVENT}

--- a/scenarios/18_the_academy.cfg
+++ b/scenarios/18_the_academy.cfg
@@ -192,6 +192,8 @@
 		{VARIABLE fire_spawn_7_13 true}
 		{VARIABLE fire_spawn_10_18 true}
 		{VARIABLE academy_current_test erinna}
+		{VARIABLE academy_guardian_spawned false}
+		{VARIABLE water_leader_spawned false}
 
 		[objectives]
 			side=1
@@ -272,6 +274,10 @@
 				boolean_equals=false
 			[/variable]
 			[and]
+				[variable]
+					name=academy_guardian_spawned
+					boolean_equals=false
+				[/variable]
 				[not]
 					[have_unit]
 						id=lava_giant
@@ -287,6 +293,7 @@
 					ai_special=guardian
 					name= _ "Fire Guardian"
 				[/unit]
+				{VARIABLE academy_guardian_spawned true}
 				{MSG instructor (_"A test guardian emerges. Defeat it to claim the key.")}
 				[scroll_to_unit]
 					[filter]
@@ -370,9 +377,9 @@
 					fire_event=no
 				[/kill]
 				[message]
-				speaker=$unit.id
-				message= _ "This must be the key. Let's now go to the Academy."
-			[/message]
+					speaker=$unit.id
+					message= _ "This must be the key. Let's now go to the Academy."
+				[/message]
 				[objectives]
 					side=1
 					[objective]
@@ -420,9 +427,9 @@
 				{CLEAR_VARIABLE sorceress_on_circle}
 				{CLEAR_VARIABLE mage_on_circle}
 				[message]
-				speaker=$unit.id
-				message= _ "Good! Just enough mana for what I need."
-			[/message]
+					speaker=$unit.id
+					message= _ "Good! Just enough mana for what I need."
+				[/message]
 				# sfx, ignore now.
 				[delay]
 					time=50
@@ -432,9 +439,9 @@
 				{MSG erinna (_"I can feel the key somewhere in that western grove.")}
 					{HIGHLIGHT_IMAGE 3 26 items/gohere.png ()}
 					[message]
-					speaker=$unit.id
-					message= _ "I have to go there."
-				[/message]
+						speaker=$unit.id
+						message= _ "I have to go there."
+					[/message]
 				# allow recruit (water elementals)
 				[modify_unit]
 					[filter]
@@ -565,9 +572,15 @@
 				name=academy_key_obtained
 				boolean_equals=true
 			[/variable]
+			[and]
+				[variable]
+					name=water_leader_spawned
+					boolean_equals=false
+				[/variable]
+			[/and]
 			[then]
 				{MSG instructor (_"$unit.name is halfway across already. Impressive.")}
-				{MSG instructor (_"Water guardians, stop her if you can. Erinna, defeat their leader to clear the Academy approach.")}
+				{MSG instructor (_"Water guardians, stop this candidate if you can. Defeat their leader to clear the Academy approach.")}
 				[unit]
 					side=4
 					type=Greater Water Daemon
@@ -584,6 +597,7 @@
 					type=Water Daemon
 					x,y=41,30
 				[/unit]
+					{VARIABLE water_leader_spawned true}
 				[objectives]
 					side=1
 					[objective]
@@ -733,6 +747,8 @@
 		[/modify_unit]
 		{VARIABLE academy_current_test sorceress}
 		{CLEAR_VARIABLE water_leader_defeated,academy_key_obtained,academy_key_dropped}
+		{VARIABLE academy_guardian_spawned false}
+		{VARIABLE water_leader_spawned false}
 		{VARIABLE sorceress_on_circle true}
 		{VARIABLE_OP academy_key_choice rand 1,2,3,4,5}
 		[if]
@@ -840,6 +856,8 @@
 		[/modify_unit]
 		{VARIABLE academy_current_test mage}
 		{CLEAR_VARIABLE water_leader_defeated,academy_key_obtained,academy_key_dropped}
+		{VARIABLE academy_guardian_spawned false}
+		{VARIABLE water_leader_spawned false}
 		{VARIABLE mage_on_circle true}
 		{VARIABLE_OP academy_key_choice rand 1,2,3,4,5}
 		[if]

--- a/scenarios/18_the_academy.cfg
+++ b/scenarios/18_the_academy.cfg
@@ -922,7 +922,7 @@
 				condition=win
 			[/objective]
 			[objective]
-				description= _ "Death of Erinna"
+				description= _ "Death of $mage.name"
 				condition=lose
 			[/objective]
 			{TURNS_RUN_OUT}

--- a/scenarios/18_the_academy.cfg
+++ b/scenarios/18_the_academy.cfg
@@ -813,7 +813,7 @@
 				condition=win
 			[/objective]
 			[objective]
-				description= _ "Death of Erinna"
+				description= _ "Death of White Sorceress"
 				condition=lose
 			[/objective]
 			{TURNS_RUN_OUT}


### PR DESCRIPTION
### Motivation

- Make scenario 18 repeat the same Academy test for three candidates (Erinna, White Sorceress, Mage) and only trigger victory after all three pass.
- Allow the White Sorceress and the Mage candidate to run the same test flow as Erinna without duplicating logic for each step.

### Description

- Generalized the trial flow in `scenarios/18_the_academy.cfg` by introducing `academy_current_test` and allowing `erinna`, `sorceress1`, or `mage` to trigger guardian/key/hotspot events and objectives.
- Reworked guardian spawn and key pickup events to check `academy_key_obtained` and existence of the guardian unit, and accept any of the three units via `id=erinna,sorceress1,mage` and dynamic `speaker/$unit.id` messages.
- Added a `sorceress_test` event that teleports actors, transforms `sorceress1` into `White Sorceress Winged`, enables recruiting `Orb`, and reinitializes the test state for her run.
- Added a `mage_test` event containing a short humor scene where the Mage summons a `Greater Wind Daemon`, banters, dismisses it, then is given `movement_type=smallfly` and an `extra_recruit` list (`Unstable Elemental,Vine Tiger,Zephyr,Stone Golem`), and reinitializes the test state; also added `academy_passed` to end the scenario with victory once all three pass.

### Testing

- Ran a WML tag-balance check script that counted `[if]/[/if]`, `[then]/[/then]`, and `[event]/[/event]` occurrences in `scenarios/18_the_academy.cfg` and verified the counts matched.
- Inspected the resulting diff of `scenarios/18_the_academy.cfg` to confirm the new `sorceress_test`, `mage_test`, `academy_passed` events and the generalization of existing events were applied as intended.
- Printed and reviewed key ranges of `scenarios/18_the_academy.cfg` with `nl`/`sed` to validate the new control-flow blocks and dynamic message replacements were inserted correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d894973148329895500a794ca58e6)